### PR TITLE
fix: add webhook to mollie hosted checkout

### DIFF
--- a/src/providers/mollie/services/mollie-provider.ts
+++ b/src/providers/mollie/services/mollie-provider.ts
@@ -5,7 +5,13 @@ class MollieProviderService extends MollieBase {
   static identifier = PaymentProviderKeys.MOLLIE_HOSTED_CHECKOUT;
 
   get paymentCreateOptions(): PaymentOptions {
-    return {};
+    return {
+      webhookUrl:
+        this.options_.medusaUrl +
+        "/hooks/payment/" +
+        PaymentProviderKeys.MOLLIE_HOSTED_CHECKOUT +
+        "_mollie",
+    };
   }
 }
 


### PR DESCRIPTION
Currently when using the Mollie hosted provider, there will be no webhook triggered.
Whit this PR, we also configure the webhook url, to have the same behavior as the other providers